### PR TITLE
dcache-namespace: add listing of file metadata

### DIFF
--- a/dcache-namespace.html
+++ b/dcache-namespace.html
@@ -235,6 +235,51 @@ _A model adapted from iron-request element of Google Polymer._
         this._send(options, action);
       },
 
+      /*
+       * ### Performs an AJAX request to get the metadata of a file.
+       *
+       * @param {{
+       *  options: (object)}} options - 
+       *    `url`: (String) The url of dcache restful-api.
+       *
+       *    `path`: (String) The path to the file you want to get it metadata.
+       *
+       *    `children`: (Boolean) Specify whether to list the children of the specified 
+       *        file path. Default to false
+       *
+       *    `locality`: (Boolean) If true, the locality of the file children will be 
+       *        added to the returned file metadata. Default to false
+       *
+       *    `limit`: (Number) Default to null
+       *
+       *    `offset`: (Number) Default to null
+       *
+       */
+      ls: function(options)
+      {
+        if (options.path !=null && !options.path.startsWith('/')) {
+          console.error('Request not send... Ensure that the path start with forward slash.');
+          return;
+        }
+        if (options.url == null) {
+          console.error('Request not send... url must be specified.');
+          return;
+        }
+        
+        var query = '';
+        query = options.path == null ? '/': options.path;
+        query = query.endsWith('/') ? query : query + '/';
+        query = options.children == true ? query + '?children=true': query + '?children=false';
+        query = options.locality == true ? query + '&locality=true': query + '&locality=false';
+        query = options.limit == null ? query: query+'&limit='+options.limit;
+        query = options.offset == null ? query: query+'&offset='+options.offset;
+
+        var url = options.url.endsWith('/') ? 
+                  options.url+'api/v1/namespace'+query : options.url+'/api/v1/namespace'+query;
+        var opt = {method:'GET', url: url}
+        this._send(opt, 'ls');
+      },
+
       /**
         * Attempts to parse the response body of the XHR. If parsing succeeds,
         * the value returned will be deserialized based on the `responseType`

--- a/demo/index.html
+++ b/demo/index.html
@@ -80,5 +80,55 @@
       </demo-snippet>
     </div>
 
+
+    <div class="vertical-section-container centered">
+      <h3>Demo: Use <code>dcache-namespace</code> element to list a file metadata</h3>
+      <demo-snippet>
+        <template>
+          <div>
+            <label>File Path: </label>
+            <input id="path" type="text">
+          </div>
+          <br>
+          <div>
+            <label>URL</label>
+            <input id="resturl" style="width:340px;" type="text" value="https://prometheus.desy.de:3880">
+          </div>
+          <br>
+          <button onclick="list()">List</button>
+          <br>
+          
+          <script>
+            function list() {
+              var namespace = document.createElement('dcache-namespace');
+              var path = document.getElementById('path').value;
+              var username = document.getElementById('username').value;
+              var password = document.getElementById('password').value;
+              var resturl = document.getElementById('resturl').value;
+              var auth = window.btoa(username +':' + password);
+              namespace.auth = auth;
+
+              namespace.promise.then(
+                function(req) {
+                  console.log(req.response);
+                }
+              ).catch(
+                function(err) {
+                  console.log(err);
+                }
+              );
+
+              namespace.ls({
+                url: resturl,
+                path: path,
+                children: true,
+                locality: true
+              });
+            }            
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
+
   </body>
 </html>


### PR DESCRIPTION
This patch add support for dcache restful api listing feature.
Simple demonstration on how to use this feature is included in
the demo page.